### PR TITLE
Post deadline

### DIFF
--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -8,6 +8,7 @@ class TripsController < ApplicationController
   end
 
   def destroy
-    binding.pry
+    Trip.find(params[:id]).travelers.destroy(params[:traveler])
+    redirect_to "/trips/#{params[:id]}"
   end
 end

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -5,6 +5,6 @@ Mileage: <%= @trip.mileage %><br>
 <h3>Travelers</h3>
 <% @trip.travelers.each do |traveler| %>
   <div id='traveler-<%=traveler.id%>'>
-    <%= traveler.name %> <%= link_to 'Remove', "/trips/#{traveler.id}", method: :delete %><br>
+    <%= traveler.name %> <%= link_to 'Remove', "/trips/#{@trip.id}?traveler=#{traveler.id}", method: :delete %><br>
   </div>
 <% end %>


### PR DESCRIPTION
late addition. i was stuck and didn't get this on my own. i have a question.

i was originally passing only traveler id in the 'remove' link. from `def destroy` in my trips controller, only having access to traveler through `traveler = Traveler.find(params[:id])`, shouldn't i still be able to find trips through activerecord? `traveler.trips` returned an unusable activerecord association.

i was able to pass the trip id and add the traveler id as a second parameter in the link and get it that way, but i have a feeling activerecord can get it done without the second parameter.